### PR TITLE
fix buffer overrun

### DIFF
--- a/Source Code/enrollment and testing/slave-cy62256nll/src/main.cpp
+++ b/Source Code/enrollment and testing/slave-cy62256nll/src/main.cpp
@@ -188,7 +188,7 @@ void readSRAMfromMicroSD(){
 }
 
 void readHelperDatafromMicroSD(){
-  memset(helper_data_new, 0, sizeof(puf_binary_new));
+  memset(helper_data_new, 0, sizeof(helper_data_new));
   uint8_t result;
 
   // read

--- a/Source Code/key storage scheme/PUF-decrypt/src/main.cpp
+++ b/Source Code/key storage scheme/PUF-decrypt/src/main.cpp
@@ -173,7 +173,7 @@ void readSRAMfromMicroSD() {
 }
 
 void readHelperDatafromMicroSD() {
-  memset(helper_data_new, 0, sizeof(puf_binary_new));
+  memset(helper_data_new, 0, sizeof(helper_data_new));
   uint8_t result;
 
   // read

--- a/Source Code/key storage scheme/PUF-encrypt/src/main.cpp
+++ b/Source Code/key storage scheme/PUF-encrypt/src/main.cpp
@@ -173,7 +173,7 @@ void readSRAMfromMicroSD() {
 }
 
 void readHelperDatafromMicroSD() {
-  memset(helper_data_new, 0, sizeof(puf_binary_new));
+  memset(helper_data_new, 0, sizeof(helper_data_new));
   uint8_t result;
 
   // read

--- a/Source Code/reconstruction/src/main.cpp
+++ b/Source Code/reconstruction/src/main.cpp
@@ -172,7 +172,7 @@ void readSRAMfromMicroSD() {
 }
 
 void readHelperDatafromMicroSD() {
-  memset(helper_data_new, 0, sizeof(puf_binary_new));
+  memset(helper_data_new, 0, sizeof(helper_data_new));
   uint8_t result;
 
   // read


### PR DESCRIPTION
memset _count_ parameter is incorrect and creates a buffer overrun.  The array `helper_data_new` (size is 259) is memset with a _count_ value of 296 (the size of the `puf_binary_new` array).